### PR TITLE
ci: unify secret scan via reusable-workflows security-scan@v1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,17 +47,5 @@ jobs:
       - name: pytest
         run: uv run pytest --no-cov
 
-  gitleaks:
-    name: gitleaks
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-
-      - name: Run gitleaks
-        uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  security:
+    uses: okamyuji/reusable-workflows/.github/workflows/security-scan.yml@v1


### PR DESCRIPTION
## Summary
- Replace the inline gitleaks job (pinned gitleaks-action@v2) with a call to okamyuji/reusable-workflows/.github/workflows/security-scan.yml@v1
- The reusable workflow pins gitleaks-action@v3, sets fetch-depth 0, and passes GITHUB_TOKEN internally
- The repo-specific quality job (uv sync, ruff, mypy, pytest with libportaudio2/libsndfile1) is kept unchanged, as no Python reusable workflow exists yet
- on: triggers and permissions (contents: read) unchanged

## Test plan
- [ ] quality (lint-and-test) passes
- [ ] security / gitleaks passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)